### PR TITLE
Fix configuration section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,16 +90,17 @@ responses = generator.generate_all(prompts)
 
 ## 🔧 Configuration
 
-All configuration details for the Moon Report Generator can be found in the `config` directory.
+Configuration details for the Moon Report Generator are documented in the contributing guide.
 
-📁 **Path:** `CONTRIBUTE.md`
+📁 Path: `CONTRIBUTE.md`
 
-This file contains detailed instructions and parameters to customize how the application behaves, including:
+This guide includes:
 
-* API keys
-* Model settings (Gemini, Groq, LLaMA3, etc.)
-* Thread settings
-* Report formatting options
+* API key setup  
+* Model configuration (Gemini, Groq, LLaMA3 via Ollama)  
+* Threading and performance settings  
+* Report formatting options  
+* Development workflow and contribution standards
 
 ---
 


### PR DESCRIPTION
This PR corrects an inconsistency in the Configuration section of the README.
The original text referenced a non-existent `config/` directory and pointed to `CONTRIBUTE.md`.
This update clarifies that configuration details are documented in `CONTRIBUTE.md` and improves the structure of the section.
